### PR TITLE
書誌統合タスクのアップデート

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
         const PASSTHROUGH = false
 
         // ワークフローid
-        const WORKFLOW_ID = '8fd4e02b-925a-472a-82d4-c81cc2a73671'
+        const WORKFLOW_ID = '8de10744-4fd8-4f6d-812e-8a5ce5404a70'
 
         // 強制コールバックを許可するドメインリスト
         const allowList = [


### PR DESCRIPTION
概要
----
- タスクに利用するデータセットのアップデートに伴い、ワークフローを変更
  - ワークフロー id を更新
  - `BibMatching_06` に対応 (おそらく小泉のアカウントでしか見られないと思う)
  - 引き継ぎのことを考え、書誌データ統合タスク用にアカウントを払い出してもいいかも
  - (セルフレビュー & マージ)